### PR TITLE
Returns empty dictionary when a match can't be found for live scores.

### DIFF
--- a/pycricbuzz/cricbuzz.py
+++ b/pycricbuzz/cricbuzz.py
@@ -93,6 +93,9 @@ class Cricbuzz():
 		try:
 			comm = self.find_match(mid)
 
+                        if comm is None:
+                            return data
+
 			batting = comm.get('bat_team')
 			if batting is None:
 				return data


### PR DESCRIPTION
Fixes the issue raised regarding fetching live scores from an old match.